### PR TITLE
removed modification of xrdp pam file for kde

### DIFF
--- a/install_esm_fedora4x_kde.sh
+++ b/install_esm_fedora4x_kde.sh
@@ -8,8 +8,6 @@ sudo dnf update -y
 sudo dnf remove -y xrdp xrdp-selinux plasma-workspace-x11
 sudo dnf install -y xrdp plasma-workspace-x11
 
-SESMAN_FILE="/etc/pam.d/xrdp-sesman"
-
 sudo systemctl enable xrdp xrdp-sesman
 
 # Create the startwm.sh file

--- a/install_esm_fedora4x_kde.sh
+++ b/install_esm_fedora4x_kde.sh
@@ -10,26 +10,6 @@ sudo dnf install -y xrdp plasma-workspace-x11
 
 SESMAN_FILE="/etc/pam.d/xrdp-sesman"
 
-# Create a backup of the original file
-sudo cp $SESMAN_FILE ${SESMAN_FILE}.bak
-
-# Use sed to perform the commenting and uncommenting
-sed -i.bak \
-    -e '/auth\s\+include\s\+password-auth/s/^/#/' \
-    -e '/account\s\+include\s\+password-auth/s/^/#/' \
-    -e '/password\s\+include\s\+password-auth/s/^/#/' \
-    -e '/session\s\+include\s\+password-auth/s/^/#/' \
-    -e '/#auth\s\+include\s\+gdm-password/s/^#//' \
-    -e '/#account\s\+include\s\+gdm-password/s/^#//' \
-    -e '/#password\s\+include\s\+gdm-password/s/^#//' \
-    -e '/#session\s\+include\s\+gdm-password/s/^#//' \
-    "$SESMAN_FILE"
-
-# Configure xrdp
-sudo sed -i "/^port=3389/c\port=vsock://-1:3389" /etc/xrdp/xrdp.ini
-sudo sed -i "/^security_layer=.*/c\security_layer=rdp" /etc/xrdp/xrdp.ini
-sudo sed -i "/^bitmap_compression=.*/c\bitmap_compression=false" /etc/xrdp/xrdp.ini
-
 sudo systemctl enable xrdp xrdp-sesman
 
 # Create the startwm.sh file


### PR DESCRIPTION
If gnome desktop was not installed prior to running the script (eg in the [original kde spin](https://fedoraproject.org/spins/kde/download)) the gdm-password pam file is not present, so login is not possible. I did not find a kde equivalent file, I removed the modification via sed. Has been tested it with an unmodified fedora 41 kde. 
Feedback is appreciated. :)